### PR TITLE
refresh maxAge before save

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,6 +64,7 @@ module.exports = function(
 				_onevent.apply(socket, _args);
 				process.nextTick( function() {
 					if (shouldSave(req)) {
+						req.session.touch();
 						req.session.save();
 					}
 				} );


### PR DESCRIPTION
We have to refresh maxAge before save to database because when we save counter expiration for Redis will not refresh and session will always expire
Data that go to database by connect-redis module
[ 'sess:6nqGXUyvUnSfAqzLa65ill63-uhH1lNs',
  '{"cookie":{"originalMaxAge":600000,"expires":"2018-06-26T09:04:43.644Z","secure":false,"httpOnly":true,"pat
h":"/"},"views":0}',
  'EX',
  588 ]
588 will next time less and less, but it have to be 600 seconds, with each next update because I set up `cookie: { maxAge: 600000, secure: 'auto' },`